### PR TITLE
docs/create packages docs

### DIFF
--- a/convert/README.md
+++ b/convert/README.md
@@ -1,0 +1,7 @@
+# convert
+
+The convert package is used for transform the tensor back into an image of the 
+original color model.
+
+Each conversion method is represented as a strategy - depending on the original 
+color model, a different strategy will be invoked.

--- a/filters/README.md
+++ b/filters/README.md
@@ -1,0 +1,14 @@
+# filters
+
+This package has the actual execution of all the filters, from cropping to blurring.
+
+This package follows the `command` design pattern, i.e, each filter (command)
+contains the computation logic in the Execute method for the filter that 
+furthermore will be invoked by the `processor`.
+
+Each filter implements the following interface (that is located in processor.go):
+```go
+type Command interface {
+	Execute(*[][]color.Color) error
+}
+```

--- a/filters/blur.go
+++ b/filters/blur.go
@@ -24,10 +24,7 @@ func (bf BlurFilter) Execute(tensor *[][]color.Color) error {
 	height := len(*tensor)
 	width := len((*tensor)[0])
 
-	copy := make([][]color.Color, height)
-	for i := range copy {
-		copy[i] = append(copy[i], (*tensor)[i]...)
-	}
+	copy := deepCopy(tensor)
 
 	for y := 0; y < height; y++ {
 		for x := 0; x < width; x++ {
@@ -43,6 +40,15 @@ func (bf BlurFilter) Execute(tensor *[][]color.Color) error {
 	}
 
 	return nil
+}
+
+// produces a deep copy from src to dst
+func deepCopy(src *[][]color.Color) (copy [][]color.Color) {
+	copy = make([][]color.Color, len(*src))
+	for i := range copy {
+		copy[i] = append(copy[i], (*src)[i]...)
+	}
+	return
 }
 
 func (bf *BlurFilter) getValuesForPixel(

--- a/filters/blur.go
+++ b/filters/blur.go
@@ -54,9 +54,11 @@ func (bf *BlurFilter) getValuesForPixel(
 	height := len(*tensor)
 	width := len((*tensor)[0])
 
-	var rnew uint8
-	var gnew uint8
-	var bnew uint8
+	var (
+		rnew uint8
+		gnew uint8
+		bnew uint8
+	)
 
 	for y := startY; y < startY+bf.kernelSize && y < height; y++ {
 		for x := startX; x < startX+bf.kernelSize && x < width; x++ {

--- a/filters/blur.go
+++ b/filters/blur.go
@@ -45,7 +45,12 @@ func (bf BlurFilter) Execute(tensor *[][]color.Color) error {
 	return nil
 }
 
-func (bf *BlurFilter) getValuesForPixel(tensor *[][]color.Color, copy *[][]color.Color, startX, startY int) (r, g, b uint8) {
+func (bf *BlurFilter) getValuesForPixel(
+	tensor *[][]color.Color,
+	copy *[][]color.Color,
+	startX,
+	startY int,
+) (r, g, b uint8) {
 	height := len(*tensor)
 	width := len((*tensor)[0])
 

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,12 @@
+# models
+
+This package is used to transform a image from a color model to another.
+
+The main difference of this package with the "convert" package is that the
+strategies of this package converts from a image.Image to a [][]color.Color,
+while the strategies from "convert" converts from [][]color.Color to image.Image
+
+You might wonder why these strategies weren't implemented in "convert" package.
+This is to avoid circular imports, as the "configs" package would have to
+import "convert" package, which already imports "configs" package, so, it would
+be impossible.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -124,6 +124,7 @@ func ConvertIntoTensor(img image.Image) [][]color.Color {
 	return pixels
 }
 
+// Creates a gaussian kernel of the given size, using the given sigma
 func GaussianKernel(size int, sigma float64) [][]float64 {
 	if size%2 == 0 {
 		size++


### PR DESCRIPTION
- docs: adds documentation to function GaussianKernel
- style: long line to be divided into many lines
- style: use simpler var declaration
- refactor: deep copy is made in its own function
- docs: create docs for filters package
- docs: create documentation for convert package
- docs: create documentation for models package
