### PR TITLE
perf/avoid processing when no flags is given

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,6 +1,8 @@
 package processor
 
-import "image/color"
+import (
+	"image/color"
+)
 
 type Command interface {
 	Execute(*[][]color.Color) error

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -35,6 +35,6 @@ func (i *Invoker) AddProcess(c Command) {
 	i.FiltersApplied++
 }
 
-func (i *Invoker) MustInvoke() bool {
+func (i *Invoker) ShouldInvoke() bool {
 	return i.FiltersApplied > 0
 }

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -7,8 +7,9 @@ type Command interface {
 }
 
 type Invoker struct {
-	processes  []Command
-	ColorModel color.Model
+	processes      []Command
+	ColorModel     color.Model
+	FiltersApplied int
 }
 
 func (i *Invoker) Invoke(tensor *[][]color.Color) error {
@@ -31,4 +32,9 @@ func (i *Invoker) SetColorModel(colorModel color.Model) {
 
 func (i *Invoker) AddProcess(c Command) {
 	i.processes = append(i.processes, c)
+	i.FiltersApplied++
+}
+
+func (i *Invoker) MustInvoke() bool {
+	return i.FiltersApplied > 0
 }


### PR DESCRIPTION
- chore: ignore vscode folder
- feat: create saturation filter
- feat: configure saturation filter flags
- fix: fix temporary blue (tempB) calculation when overflows
- style: remove commented code block
- fix: return alpha channel as fully opaque even when saturation is equal 0
- feat: Min and Max functions are generic
- refactor: transfer HSL definition to its own package
- fix: check if brightness flag is different of 1.0 to perform process
- feat: create field to track the filters quantity
- refactor: MustInvoke name is ShouldInvoke for better legibility
- perf: avoid processing when no flags is given
